### PR TITLE
Update menu.cfg

### DIFF
--- a/klippy/extras/display/menu.cfg
+++ b/klippy/extras/display/menu.cfg
@@ -164,19 +164,19 @@ name: SD Card
 
 [menu __main __sdcard __start]
 type: command
-enable: {('virtual_sdcard' in printer) and not printer.idle_timeout.state == "Printing"}
+enable: {('virtual_sdcard' in printer) and and printer.print_stats.state == "standby"}
 name: Start printing
 gcode: M24
 
 [menu __main __sdcard __resume]
 type: command
-enable: {('virtual_sdcard' in printer) and printer.idle_timeout.state == "Printing"}
+enable: {('virtual_sdcard' in printer) and printer.print_stats.state == "paused"}
 name: Resume printing
 gcode: M24
 
 [menu __main __sdcard __pause]
 type: command
-enable: {('virtual_sdcard' in printer) and printer.idle_timeout.state == "Printing"}
+enable: {('virtual_sdcard' in printer) and printer.print_stats.state == "printing"}
 name: Pause printing
 gcode: M25
 


### PR DESCRIPTION
Change sd card menu enable condition.
I think the SD card menu should use <code>printer.print_stats.state</code> instead of <code>printer.idle_timeout.state</code> because of the bellow reasons.

- When paused, the "Resume" option does not show up because at that time <code>printer.idle_timeout.state = "Ready"</code>  
- The "Resume" option show up even when printing.
- When paused, only "Start" option is available, it should be "Resume" (i known they use the same Gcode, but its confusing)